### PR TITLE
Check conventional commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.11.8
     hooks:
       # Linter
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,9 @@ repos:
     rev: v0.19.1
     hooks:
       - id: gitlint
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.1.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [ commit-msg ]


### PR DESCRIPTION
### Changes

chore(pre-commit): add conventional-pre-commit hook

- Add conventional-pre-commit repo and hook for commit message linting
- Specify stages as commit-msg for the new hook

Bump Ruff pre-commit hook version from v0.11.7 to v0.11.8